### PR TITLE
Change this otherwise it takes to phishing domain

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -40,7 +40,7 @@
   <!-- Additional SEO -->
   <meta name="robots" content="index, follow" />
   <meta name="author" content="BALL x PIT Evolution Chart" />
-  <link rel="canonical" href="https://your-domain.com" />
+  <link rel="canonical" href="https://ballxpit.netlify.app/" />
 </svelte:head>
 
 {#if env.isDev && env.isDebug}


### PR DESCRIPTION
<img width="887" height="912" alt="image" src="https://github.com/user-attachments/assets/3689b11f-9734-4923-bda7-6f2a0125c29d" />
your-domain.com by default re-dirs users over to a phishing domain. let's modify this. 

<img width="1771" height="508" alt="image" src="https://github.com/user-attachments/assets/71d67869-8efd-4913-a416-824c225adc1b" />
