### PR TITLE
Add text for evolution recipes on GridItem tooltips

### DIFF
--- a/src/constants/ballEvolutions.ts
+++ b/src/constants/ballEvolutions.ts
@@ -1,4 +1,5 @@
 import type { Balls, StarterBalls } from '../types/balls.ts';
+import { ballInformation } from './ballInformation.ts';
 
 export const advancedEvolutions: [Balls, Balls, Balls][] = [
   ['bomb', 'poison', 'nuclearBomb'],
@@ -63,6 +64,15 @@ export const basicEvolutions: [StarterBalls, StarterBalls, Balls][] = [
   ['lightning', 'wind', 'storm'],
   ['poison', 'wind', 'noxious'],
 ];
+
+export function getEvolutionRecipe(ball: Balls): string | null {
+  const matches = basicEvolutions
+    .filter(([, , result]) => result === ball)
+    .map(([a, b]) => `${ballInformation[a].name} x ${ballInformation[b].name}`);
+
+  if (matches.length === 0) return null;
+  return matches.join(' / ');
+}
 
 function buildEvolutionMap() {
   const evolutionMap: Partial<Record<Balls, Partial<Record<Balls, Record<'evolution', Balls>>>>> =

--- a/src/constants/ballEvolutions.ts
+++ b/src/constants/ballEvolutions.ts
@@ -65,13 +65,37 @@ export const basicEvolutions: [StarterBalls, StarterBalls, Balls][] = [
   ['poison', 'wind', 'noxious'],
 ];
 
-export function getEvolutionRecipe(ball: Balls): string | null {
-  const matches = basicEvolutions
+export function getEvolutionRecipes(ball: Balls): string | null {
+  let matches = basicEvolutions
     .filter(([, , result]) => result === ball)
     .map(([a, b]) => `${ballInformation[a].name} x ${ballInformation[b].name}`);
 
   if (matches.length === 0) return null;
-  return matches.join(' / ');
+
+  // Condense Laser (Horizontal) and Laser (Vertical) recipes into Laser (Either)
+  const isLaser = (s: string) =>
+    /Laser\s*\((Horizontal|Vertical)\)/i.test(s);
+
+  const normalizeLaser = (s: string) =>
+    s.replace(/Laser\s*\((Horizontal|Vertical)\)/gi, "Laser (Either)");
+
+  const condensed: string[] = [];
+
+  for (const m of matches) {
+    const [left, right] = m.split(" x ");
+
+    if (isLaser(left) && isLaser(right)) {
+      condensed.push(m);
+      continue;
+    }
+
+    const normLeft = isLaser(left) ? normalizeLaser(left) : left;
+    const normRight = isLaser(right) ? normalizeLaser(right) : right;
+
+    condensed.push(`${normLeft} x ${normRight}`);
+  }
+
+  return [...new Set(condensed)].join(" / ");
 }
 
 function buildEvolutionMap() {

--- a/src/constants/ballInformation.ts
+++ b/src/constants/ballInformation.ts
@@ -6,6 +6,7 @@ export const allBalls = Object.keys(assetMap.ballIcons) as Balls[];
 export type BallInfo = {
   name: string;
   description: string;
+  evolution?: string;
   // TODO: Character that starts with this ball
   starterCharacter?: string;
 };

--- a/src/constants/ballInformation.ts
+++ b/src/constants/ballInformation.ts
@@ -16,205 +16,250 @@ export const ballInformation: Record<Balls, BallInfo> = {
     name: 'Assassin',
     description:
       'Passes through the front of enemies, but not the back. Backstabs deal 30% bonus damage.',
+    evolution: 'Dark x Iron / Ghost x Iron',
   },
   berserk: {
     name: 'Berserk',
     description:
       'Each hit has a 30% chance of causing enemies to go berserk for 6 seconds. Berserk enemies deal 15-24 damage to adjacent enemies every second.',
+    evolution: 'Bleed x Charm / Burn x Charm',
   },
   blackHole: {
     name: 'Black Hole',
     description:
       'Instantly kills the first non-boss enemy that it hits, but destroys itself afterwards. Has a 7 second cooldown, before it can be shot again.',
+    evolution: 'Dark x Sun'
   },
   blizzard: {
     name: 'Blizzard',
-    description: 'Freezes all enemies within a 2 tile radius for 0.8 seconds, dealing 1-50 damage.',
+    description:
+      'Freezes all enemies within a 2 tile radius for 0.8 seconds, dealing 1-50 damage.',
+    evolution: 'Freeze x Lightning / Freeze x Wind',
   },
   bomb: {
     name: 'Bomb',
     description:
       'Explodes when hitting an enemy, dealing 150-300 damage to nearby enemies. Has a 3 second cooldown before it can be shot again.',
+    evolution: 'Burn x Iron',
   },
   flash: {
     name: 'Flash',
     description:
       'Damage all enemies on screen for 1-3 damage after hitting an enemy and blind them for 2 seconds.',
+    evolution: 'Light x Lightning',
   },
   flicker: {
     name: 'Flicker',
     description: 'Deals 1-7 damage to every enemy on screen every 1.4 seconds.',
+    evolution: 'Dark x Light',
   },
   freezeRay: {
     name: 'Freeze Ray',
     description:
       'Emits a freeze ray when hitting an enemy, dealing 20-50 to all enemies in its path, with a 10% chance of freezing them for 10.0 seconds.',
+    evolution: 'Freeze x Laser (Horizontal) / Freeze x Laser (Vertical)',
   },
   frozenFlame: {
     name: 'Frozen Flame',
     description:
       'Add 1 stack of frostburn on hit for 20 seconds (max 4 stacks). Frostburnt units are dealt 8-12 damage per stack per second and receive 25% more damage from other sources.',
+    evolution: 'Burn x Freeze',
   },
   glacier: {
     name: 'Glacier',
     description:
       'Release glacial spikes over time that deal 15-30 to enemies that touch them and freeze them for 2.0 seconds. This ball and its glacial spikes also deal 6-12 damage to nearby units.',
+    evolution: 'Earthquake x Freeze',
   },
   hemorrhage: {
     name: 'Hemorrhage',
     description:
       'Inflicts 3 stacks of bleed. When hitting an enemy with 12 stacks of bleed or more, consumes all stacks of bleed to deal 20% of current health.',
+    evolution: 'Bleed x Iron',
   },
   holyLaser: {
     name: 'Holy Laser',
     description: 'Deals 24-36 damage to all enemies in the same row and column.',
+    evolution: 'Laser (Horizontal) x Laser (Vertical)',
   },
   incubus: {
     name: 'Incubus',
     description:
       'Each hit has a 4% chance of charming the enemy for 9 seconds. Charmed enemies curse nearby enemies. Cursed enemies are dealt 100-200 after being hit 5 times.',
+    evolution: 'Charm x Dark',
   },
   inferno: {
     name: 'Inferno',
     description:
       'Applies 1 stack of burn every second to all enemies within a 2 tile radius. Burn lasts for 6 seconds, dealing 3-7 damage per stack per second.',
+    evolution: 'Burn x Wind',
   },
   laserBeam: {
     name: 'Laser Beam',
     description:
       'Emit a laser beam on hit that deals 30-42 damage and blinds enemies for 8 seconds.',
+    evolution: 'Laser (Horizontal) x Light / Laser (Vertical) x Light',
   },
   leech: {
     name: 'Leech',
     description:
       'Attaches up to 1 leech onto enemies it hits, which adds 2 stacks of bleed per second (Max 24 stacks).',
+    evolution: 'Bleed x Brood Mother',
   },
   lightningRod: {
     name: 'Lightning Rod',
     description:
       'Plants a lightning rod into enemies it hits. These enemies are struck by lightning every 3. seconds, dealing 1-30 damage to up to 8 nearby enemies.',
+    evolution: 'Iron x Lightning',
   },
   lovestruck: {
     name: 'Lovestruck',
     description:
       'Inflicts lovestruck on hit enemies for 20 seconds. Lovestruck units have a 50% chance of healing you for 5 health when they attack.',
+    evolution: 'Charm x Light / Charm x Lightning',
   },
   maggot: {
     name: 'Maggot',
     description:
       'Infest enemies on hit with maggots. When they die, they explode into 1-2 baby balls.',
+    evolution: 'Brood Mother x Cell',
   },
   magma: {
     name: 'Magma',
     description:
       'Emits lava blobs over time. Enemies who walk into lava blobs are dealt 15-30 damage and gain 1 stack of burn (max 3 stacks). Burn lasts for 3 seconds, dealing 3-8 damage per stack per second. This ball and its lava blobs also deal 6-12 damage to nearby units.',
+    evolution: 'Burn x Earthquake',
   },
   mosquitoKing: {
     name: 'Mosquito King',
     description:
       'Spawns a mosquito each time it hits an enemy. Mosquitos attack a random enemy, dealing 80-120 damage each. If a mosquito kills an enemy, they steal 1 health.',
+    evolution: 'Brood Mother x Vampire',
   },
   mosquitoSwarm: {
     name: 'Mosquito Swarm',
     description:
       'Explodes into 3-6 mosquitos. Mosquitos attack random enemies, dealing 80-120 damage each. If a mosquito kills an enemy, they steal 1 health.',
+    evolution: 'Egg Sac x Vampire',
   },
   noxious: {
     name: 'Noxious',
     description:
       'Passes through enemies and applies 3 stacks of poison to nearby enemies with a 2 tile radius. Poison lasts 4 seconds and each stack deals 1-3 damage per second.',
+    evolution: 'Dark x Wind / Poison x Wind',
   },
   nuclearBomb: {
     name: 'Nuclear Bomb',
     description:
       'Explodes when hitting an enemy, dealing 300-500 damage to nearby enemies and applying 1 stack of radiation to everyone present indefinitely (max 5 stacks). Each stack of radiation increases damage received by 10%. Has a 3 second cooldown.',
+    evolution: 'Bomb x Poison'
   },
   overgrowth: {
     name: 'Overgrowth',
     description:
       'Applies 1 stack of overgrowth. Upon reaching 3, consume all stacks and deal 150-200 damage to all enemies in a 3x3 tile square.',
+    evolution: 'Cell x Earthquake',
   },
   phantom: {
     name: 'Phantom',
     description:
       'Curse enemies on hit. Cursed enemies are dealt 100-200 damage after being hit 5 times.',
+    evolution: 'Dark x Ghost',
   },
   radiationBeam: {
     name: 'Radiation Beam',
     description:
       'Emit a radiation beam on hit that deals 24-48 damage and applies 1 stack of radiation (max 5 stacks). Radiation lasts for 15 seconds and cause enemies to receive 10% more damage from all sources per stack.',
+    evolution:
+      'Cell x Laser (Horizontal) / Cell x Laser (Vertical) / Laser (Horizontal) x Poison / Laser (Vertical) x Poison',
   },
   sacrifice: {
     name: 'Sacrifice',
     description:
       'Inflicts 4 stacks of bleed (Max 15 stacks) and applies curse to hit enemies. Cursed enemies are dealt 50-100 after being hit 5 times.',
+    evolution: 'Bleed x Dark',
   },
   sandstorm: {
     name: 'Sandstorm',
     description:
       'Goes through enemies and is surrounded by a raging storm dealing 10-20 damage per second and blinding nearby enemies for 3 seconds.',
+    evolution: 'Earthquake x Wind',
   },
   satan: {
     name: 'Satan',
     description:
       'While active, add 1 stack of burn to all enemies per second (max 5 stacks), dealing 10-20 damage per stack per second and make them go berserk, dealing 15-24 damage to adjacent enemies every second.',
+    evolution: 'Incubus + Succubus'
   },
   shotgun: {
     name: 'Shotgun',
     description:
       'Shoots 3-7 iron baby balls after hitting a wall. Iron baby balls move at 200% speed but are destroyed upon hitting anything.',
+    evolution: 'Egg Sac x Iron',
   },
   soulSucker: {
     name: 'Soul Sucker',
     description:
       'Passes through enemies and saps them, with a 30% chance of stealing 1 health and reducing their attack damage by 20%. Lifesteal chance only applies once per enemy.',
+    evolution: 'Ghost x Vampire',
   },
   spiderQueen: {
     name: 'Spider Queen',
     description: 'Has a 25% chance of birthing an Egg Sac each time it hits an enemy.',
+    evolution: 'Brood Mother x Egg Sac',
   },
   storm: {
     name: 'Storm',
-    description: 'Emits lightning to strike nearby enemies every second, dealing 1-40 damage.',
+    description:
+      'Emits lightning to strike nearby enemies every second, dealing 1-40 damage.',
+    evolution: 'Lightning x Wind',
   },
   succubus: {
     name: 'Succubus',
     description:
       'Each hit has a 4% chance of charming the enemy for 9 seconds. Heals 1 when hitting a charmed enemy.',
+    evolution: 'Charm x Vampire',
   },
   sun: {
     name: 'Sun',
     description:
       'Blind all enemies in view and add 1 stack of burn every second (max 5 stacks). Burn lasts for 6 seconds and deals 6-12 damage per stack per second.',
+    evolution: 'Burn x Light',
   },
   swamp: {
     name: 'Swamp',
     description:
       'Leaves behind tar blobs over time. Enemies who walk into tar blobs are dealt 15-30 damage, are slowed by 50% for 7 seconds and gain 1 stack of poison (max 8 stacks). Each stack of poison deals 1-3 damage per second. This ball and its tar blobs also deal 6-12 damage to nearby units.',
+    evolution: 'Earthquake x Poison',
   },
   vampireLord: {
     name: 'Vampire Lord',
     description:
       'Each hit inflicts 3 stacks of bleed. Heals 1 health and consumes all stacks when hitting an enemy with at least 10 stacks of bleed.',
+    evolution: 'Bleed x Vampire / Dark x Vampire',
   },
   virus: {
     name: 'Virus',
     description:
       'Applies 1 stack of disease to units it hits (max 8 stacks). Disease lasts for 6 seconds. Each stack of disease deals 3-6 damage per second and diseased units have a 15% chance of passing a stack to undiseased nearby enemies each second.',
+    evolution: 'Bleed x Poison / Cell x Poison / Ghost x Poison',
   },
   voluptuousEggSac: {
     name: 'Voluptuous Egg Sac',
     description:
       'Explodes into 2-3 egg sacs on hitting an enemy. Has a 3 second cooldown before it can be shot again.',
+    evolution: 'Cell x Egg Sac',
   },
   wraith: {
     name: 'Wraith',
     description: 'Freezes any enemy it passes through for 0.8 seconds.',
+    evolution: 'Freeze x Ghost',
   },
   nosferatu: {
     name: 'Nosferatu',
     description:
       'Spawns a vampire bat each bounce. Vampire bats fly towards a random enemy, dealing 132-176 damage on hit, turning into a Vampire Lord.',
+    evolution: 'Vampire Lord x Mosquito King x Spider Queen'
   },
   bleed: {
     name: 'Bleed',
@@ -223,7 +268,8 @@ export const ballInformation: Record<Balls, BallInfo> = {
   },
   broodMother: {
     name: 'Brood Mother',
-    description: 'Has a 25 percent chance of birthing a baby ball each time it hits an enemy.',
+    description:
+      'Has a 25 percent chance of birthing a baby ball each time it hits an enemy.',
   },
   burn: {
     name: 'Burn',

--- a/src/constants/ballInformation.ts
+++ b/src/constants/ballInformation.ts
@@ -6,7 +6,6 @@ export const allBalls = Object.keys(assetMap.ballIcons) as Balls[];
 export type BallInfo = {
   name: string;
   description: string;
-  evolution?: string;
   // TODO: Character that starts with this ball
   starterCharacter?: string;
 };
@@ -16,250 +15,207 @@ export const ballInformation: Record<Balls, BallInfo> = {
     name: 'Assassin',
     description:
       'Passes through the front of enemies, but not the back. Backstabs deal 30% bonus damage.',
-    evolution: 'Dark x Iron / Ghost x Iron',
   },
   berserk: {
     name: 'Berserk',
     description:
       'Each hit has a 30% chance of causing enemies to go berserk for 6 seconds. Berserk enemies deal 15-24 damage to adjacent enemies every second.',
-    evolution: 'Bleed x Charm / Burn x Charm',
   },
   blackHole: {
     name: 'Black Hole',
     description:
       'Instantly kills the first non-boss enemy that it hits, but destroys itself afterwards. Has a 7 second cooldown, before it can be shot again.',
-    evolution: 'Dark x Sun'
   },
   blizzard: {
     name: 'Blizzard',
     description:
       'Freezes all enemies within a 2 tile radius for 0.8 seconds, dealing 1-50 damage.',
-    evolution: 'Freeze x Lightning / Freeze x Wind',
   },
   bomb: {
     name: 'Bomb',
     description:
       'Explodes when hitting an enemy, dealing 150-300 damage to nearby enemies. Has a 3 second cooldown before it can be shot again.',
-    evolution: 'Burn x Iron',
   },
   flash: {
     name: 'Flash',
     description:
       'Damage all enemies on screen for 1-3 damage after hitting an enemy and blind them for 2 seconds.',
-    evolution: 'Light x Lightning',
   },
   flicker: {
     name: 'Flicker',
     description: 'Deals 1-7 damage to every enemy on screen every 1.4 seconds.',
-    evolution: 'Dark x Light',
   },
   freezeRay: {
     name: 'Freeze Ray',
     description:
       'Emits a freeze ray when hitting an enemy, dealing 20-50 to all enemies in its path, with a 10% chance of freezing them for 10.0 seconds.',
-    evolution: 'Freeze x Laser (Horizontal) / Freeze x Laser (Vertical)',
   },
   frozenFlame: {
     name: 'Frozen Flame',
     description:
       'Add 1 stack of frostburn on hit for 20 seconds (max 4 stacks). Frostburnt units are dealt 8-12 damage per stack per second and receive 25% more damage from other sources.',
-    evolution: 'Burn x Freeze',
   },
   glacier: {
     name: 'Glacier',
     description:
       'Release glacial spikes over time that deal 15-30 to enemies that touch them and freeze them for 2.0 seconds. This ball and its glacial spikes also deal 6-12 damage to nearby units.',
-    evolution: 'Earthquake x Freeze',
   },
   hemorrhage: {
     name: 'Hemorrhage',
     description:
       'Inflicts 3 stacks of bleed. When hitting an enemy with 12 stacks of bleed or more, consumes all stacks of bleed to deal 20% of current health.',
-    evolution: 'Bleed x Iron',
   },
   holyLaser: {
     name: 'Holy Laser',
     description: 'Deals 24-36 damage to all enemies in the same row and column.',
-    evolution: 'Laser (Horizontal) x Laser (Vertical)',
   },
   incubus: {
     name: 'Incubus',
     description:
       'Each hit has a 4% chance of charming the enemy for 9 seconds. Charmed enemies curse nearby enemies. Cursed enemies are dealt 100-200 after being hit 5 times.',
-    evolution: 'Charm x Dark',
   },
   inferno: {
     name: 'Inferno',
     description:
       'Applies 1 stack of burn every second to all enemies within a 2 tile radius. Burn lasts for 6 seconds, dealing 3-7 damage per stack per second.',
-    evolution: 'Burn x Wind',
   },
   laserBeam: {
     name: 'Laser Beam',
     description:
       'Emit a laser beam on hit that deals 30-42 damage and blinds enemies for 8 seconds.',
-    evolution: 'Laser (Horizontal) x Light / Laser (Vertical) x Light',
   },
   leech: {
     name: 'Leech',
     description:
       'Attaches up to 1 leech onto enemies it hits, which adds 2 stacks of bleed per second (Max 24 stacks).',
-    evolution: 'Bleed x Brood Mother',
   },
   lightningRod: {
     name: 'Lightning Rod',
     description:
       'Plants a lightning rod into enemies it hits. These enemies are struck by lightning every 3. seconds, dealing 1-30 damage to up to 8 nearby enemies.',
-    evolution: 'Iron x Lightning',
   },
   lovestruck: {
     name: 'Lovestruck',
     description:
       'Inflicts lovestruck on hit enemies for 20 seconds. Lovestruck units have a 50% chance of healing you for 5 health when they attack.',
-    evolution: 'Charm x Light / Charm x Lightning',
   },
   maggot: {
     name: 'Maggot',
     description:
       'Infest enemies on hit with maggots. When they die, they explode into 1-2 baby balls.',
-    evolution: 'Brood Mother x Cell',
   },
   magma: {
     name: 'Magma',
     description:
       'Emits lava blobs over time. Enemies who walk into lava blobs are dealt 15-30 damage and gain 1 stack of burn (max 3 stacks). Burn lasts for 3 seconds, dealing 3-8 damage per stack per second. This ball and its lava blobs also deal 6-12 damage to nearby units.',
-    evolution: 'Burn x Earthquake',
   },
   mosquitoKing: {
     name: 'Mosquito King',
     description:
       'Spawns a mosquito each time it hits an enemy. Mosquitos attack a random enemy, dealing 80-120 damage each. If a mosquito kills an enemy, they steal 1 health.',
-    evolution: 'Brood Mother x Vampire',
   },
   mosquitoSwarm: {
     name: 'Mosquito Swarm',
     description:
       'Explodes into 3-6 mosquitos. Mosquitos attack random enemies, dealing 80-120 damage each. If a mosquito kills an enemy, they steal 1 health.',
-    evolution: 'Egg Sac x Vampire',
   },
   noxious: {
     name: 'Noxious',
     description:
       'Passes through enemies and applies 3 stacks of poison to nearby enemies with a 2 tile radius. Poison lasts 4 seconds and each stack deals 1-3 damage per second.',
-    evolution: 'Dark x Wind / Poison x Wind',
   },
   nuclearBomb: {
     name: 'Nuclear Bomb',
     description:
       'Explodes when hitting an enemy, dealing 300-500 damage to nearby enemies and applying 1 stack of radiation to everyone present indefinitely (max 5 stacks). Each stack of radiation increases damage received by 10%. Has a 3 second cooldown.',
-    evolution: 'Bomb x Poison'
   },
   overgrowth: {
     name: 'Overgrowth',
     description:
       'Applies 1 stack of overgrowth. Upon reaching 3, consume all stacks and deal 150-200 damage to all enemies in a 3x3 tile square.',
-    evolution: 'Cell x Earthquake',
   },
   phantom: {
     name: 'Phantom',
     description:
       'Curse enemies on hit. Cursed enemies are dealt 100-200 damage after being hit 5 times.',
-    evolution: 'Dark x Ghost',
   },
   radiationBeam: {
     name: 'Radiation Beam',
     description:
       'Emit a radiation beam on hit that deals 24-48 damage and applies 1 stack of radiation (max 5 stacks). Radiation lasts for 15 seconds and cause enemies to receive 10% more damage from all sources per stack.',
-    evolution:
-      'Cell x Laser (Horizontal) / Cell x Laser (Vertical) / Laser (Horizontal) x Poison / Laser (Vertical) x Poison',
   },
   sacrifice: {
     name: 'Sacrifice',
     description:
       'Inflicts 4 stacks of bleed (Max 15 stacks) and applies curse to hit enemies. Cursed enemies are dealt 50-100 after being hit 5 times.',
-    evolution: 'Bleed x Dark',
   },
   sandstorm: {
     name: 'Sandstorm',
     description:
       'Goes through enemies and is surrounded by a raging storm dealing 10-20 damage per second and blinding nearby enemies for 3 seconds.',
-    evolution: 'Earthquake x Wind',
   },
   satan: {
     name: 'Satan',
     description:
       'While active, add 1 stack of burn to all enemies per second (max 5 stacks), dealing 10-20 damage per stack per second and make them go berserk, dealing 15-24 damage to adjacent enemies every second.',
-    evolution: 'Incubus + Succubus'
   },
   shotgun: {
     name: 'Shotgun',
     description:
       'Shoots 3-7 iron baby balls after hitting a wall. Iron baby balls move at 200% speed but are destroyed upon hitting anything.',
-    evolution: 'Egg Sac x Iron',
   },
   soulSucker: {
     name: 'Soul Sucker',
     description:
       'Passes through enemies and saps them, with a 30% chance of stealing 1 health and reducing their attack damage by 20%. Lifesteal chance only applies once per enemy.',
-    evolution: 'Ghost x Vampire',
   },
   spiderQueen: {
     name: 'Spider Queen',
     description: 'Has a 25% chance of birthing an Egg Sac each time it hits an enemy.',
-    evolution: 'Brood Mother x Egg Sac',
   },
   storm: {
     name: 'Storm',
     description:
       'Emits lightning to strike nearby enemies every second, dealing 1-40 damage.',
-    evolution: 'Lightning x Wind',
   },
   succubus: {
     name: 'Succubus',
     description:
       'Each hit has a 4% chance of charming the enemy for 9 seconds. Heals 1 when hitting a charmed enemy.',
-    evolution: 'Charm x Vampire',
   },
   sun: {
     name: 'Sun',
     description:
       'Blind all enemies in view and add 1 stack of burn every second (max 5 stacks). Burn lasts for 6 seconds and deals 6-12 damage per stack per second.',
-    evolution: 'Burn x Light',
   },
   swamp: {
     name: 'Swamp',
     description:
       'Leaves behind tar blobs over time. Enemies who walk into tar blobs are dealt 15-30 damage, are slowed by 50% for 7 seconds and gain 1 stack of poison (max 8 stacks). Each stack of poison deals 1-3 damage per second. This ball and its tar blobs also deal 6-12 damage to nearby units.',
-    evolution: 'Earthquake x Poison',
   },
   vampireLord: {
     name: 'Vampire Lord',
     description:
       'Each hit inflicts 3 stacks of bleed. Heals 1 health and consumes all stacks when hitting an enemy with at least 10 stacks of bleed.',
-    evolution: 'Bleed x Vampire / Dark x Vampire',
   },
   virus: {
     name: 'Virus',
     description:
       'Applies 1 stack of disease to units it hits (max 8 stacks). Disease lasts for 6 seconds. Each stack of disease deals 3-6 damage per second and diseased units have a 15% chance of passing a stack to undiseased nearby enemies each second.',
-    evolution: 'Bleed x Poison / Cell x Poison / Ghost x Poison',
   },
   voluptuousEggSac: {
     name: 'Voluptuous Egg Sac',
     description:
       'Explodes into 2-3 egg sacs on hitting an enemy. Has a 3 second cooldown before it can be shot again.',
-    evolution: 'Cell x Egg Sac',
   },
   wraith: {
     name: 'Wraith',
     description: 'Freezes any enemy it passes through for 0.8 seconds.',
-    evolution: 'Freeze x Ghost',
   },
   nosferatu: {
     name: 'Nosferatu',
     description:
       'Spawns a vampire bat each bounce. Vampire bats fly towards a random enemy, dealing 132-176 damage on hit, turning into a Vampire Lord.',
-    evolution: 'Vampire Lord x Mosquito King x Spider Queen'
   },
   bleed: {
     name: 'Bleed',

--- a/src/lib/components/GridItem.svelte
+++ b/src/lib/components/GridItem.svelte
@@ -51,6 +51,11 @@
       <div class="font-bold text-yellow-400 mb-1">
         {ballInformation[ballKey].name}
       </div>
+      {#if ballInformation[ballKey].evolution}
+      <div>
+        {ballInformation[ballKey].evolution}
+      </div>
+      {/if}
       <div class="text-sm">
         {ballInformation[ballKey].description}
       </div>

--- a/src/lib/components/GridItem.svelte
+++ b/src/lib/components/GridItem.svelte
@@ -52,9 +52,13 @@
         {ballInformation[ballKey].name}
       </div>
       {#if ballInformation[ballKey].evolution}
-      <div>
-        {ballInformation[ballKey].evolution}
-      </div>
+        <div>
+          {#each ballInformation[ballKey].evolution.split('/') as evolutionText}
+            <div class="text-gray-400 mb-1">
+              {evolutionText.trim()}
+            </div>
+          {/each}
+        </div>
       {/if}
       <div class="text-sm">
         {ballInformation[ballKey].description}

--- a/src/lib/components/GridItem.svelte
+++ b/src/lib/components/GridItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ballInformation } from '../../constants/ballInformation.ts';
+  import { getEvolutionRecipe } from '../../constants/ballEvolutions.ts';
   import { passiveInformation } from '../../constants/passiveInformation.ts';
   import type { Balls } from '../../types/balls.ts';
   import type { Passives } from '../../types/passives.ts';
@@ -51,9 +52,9 @@
       <div class="font-bold text-yellow-400 mb-1">
         {ballInformation[ballKey].name}
       </div>
-      {#if ballInformation[ballKey].evolution}
+      {#if getEvolutionRecipe(ballKey)}
         <div>
-          {#each ballInformation[ballKey].evolution.split('/') as evolutionText}
+          {#each getEvolutionRecipe(ballKey)?.split('/') as evolutionText}
             <div class="text-gray-400 mb-1">
               {evolutionText.trim()}
             </div>

--- a/src/lib/components/GridItem.svelte
+++ b/src/lib/components/GridItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ballInformation } from '../../constants/ballInformation.ts';
-  import { getEvolutionRecipe } from '../../constants/ballEvolutions.ts';
+  import { getEvolutionRecipes } from '../../constants/ballEvolutions.ts';
   import { passiveInformation } from '../../constants/passiveInformation.ts';
   import type { Balls } from '../../types/balls.ts';
   import type { Passives } from '../../types/passives.ts';
@@ -52,9 +52,9 @@
       <div class="font-bold text-yellow-400 mb-1">
         {ballInformation[ballKey].name}
       </div>
-      {#if getEvolutionRecipe(ballKey)}
+      {#if getEvolutionRecipes(ballKey)}
         <div>
-          {#each getEvolutionRecipe(ballKey)?.split('/') as evolutionText}
+          {#each getEvolutionRecipes(ballKey)?.split('/') as evolutionText}
             <div class="text-gray-400 mb-1">
               {evolutionText.trim()}
             </div>


### PR DESCRIPTION
Hey! Thanks for creating this site! I always have it open on my side-screen while playing :)

The one thing I feel its missing is having the recipes laid out on the tooltips for each ball. This is useful when I'm trying to get a specific evolution (i.e. Nosferatu) but dont want to have to find each individual component ball in the chart. This is also useful for some of the balls on the chart where the tooltip blocks the ball that is used to create the evolution.

Let me know if you think this is a useful add or if there are any changes you think I should make.